### PR TITLE
Allow the user to specify the serial number of the FX3 board to connect to.

### DIFF
--- a/src_wrapper/Wrapper.cs
+++ b/src_wrapper/Wrapper.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Copyright (c) 2018-2020 Analog Devices, Inc. All Rights Reserved.
  * This software is proprietary to Analog Devices, Inc. and its licensors.
  * 
@@ -85,10 +85,11 @@ namespace FX3ApiWrapper
         /// <param name="FX3ResourcePath">Path the FX3 firmware binaries</param>
         /// <param name="RegMapPath">Path to register map file</param>
         /// <param name="Type"></param>
-        public Wrapper(string FX3ResourcePath, string RegMapPath, SensorType Type)
+        /// <param name="FX3SerialNumber">Serial number of board to connect to (optional)</param>
+        public Wrapper(string FX3ResourcePath, string RegMapPath, SensorType Type, System.String FX3SerialNumber = null)
         {
             FX3 = new FX3Connection(FX3ResourcePath, FX3ResourcePath, FX3ResourcePath);
-            ConnectToBoard();
+            ConnectToBoard(FX3SerialNumber: FX3SerialNumber);
             UpdateDutType(Type);
             UpdateRegMap(RegMapPath);
         }
@@ -763,10 +764,16 @@ namespace FX3ApiWrapper
         /// <summary>
         /// Connect to FX3 board
         /// </summary>
-        private void ConnectToBoard()
+        /// <param name="FX3SerialNumber">Serial number of board to connect to (optional)</param>
+        private void ConnectToBoard(System.String FX3SerialNumber = null)
         {
             FX3.WaitForBoard(2);
-            if (FX3.AvailableFX3s.Count() > 0)
+            // If a serial number is specified, then connect to that board
+            if (FX3SerialNumber != null)
+            {
+                FX3.Connect(FX3SerialNumber);
+            }
+            else if (FX3.AvailableFX3s.Count() > 0)
             {
                 FX3.Connect(FX3.AvailableFX3s[0]);
             }


### PR DESCRIPTION
Allow the user to specify the serial number for the board to connect to. This was not previously possible. My application for this was that I needed to simultaneously read measurements from two separate IMUs that are each connected to their own FX3 boards (i.e., using two USB cables, I connected to two separate FX3 boards, which each connected to their corresponding IMU).

I had to change the `Wrapper.cs` file, build, and then move the generated `FX3ApiWrapper.dll` file to the right directory to use this new `.dll` from Python using `pythonnet`. I also made sure that this change does not break previous implementations.

For example, both this call in Python (old version):
```python
IMU = FX3ApiWrapper.Wrapper(
    assets_dir,
    assets_dir + "\\ADIS1647x_RegMap.csv",
    FX3ApiWrapper.SensorType.StandardImu
)
```
and this call in Python (new version):
```python
IMU = FX3ApiWrapper.Wrapper(
    assets_dir,
    assets_dir + "\\ADIS1647x_RegMap.csv",
    FX3ApiWrapper.SensorType.StandardImu,
    "0009012D07011512"
)
```
both work.